### PR TITLE
Adjusting document check for SSR

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export interface ScrollbarWidth {
 export const scrollbarWidth: ScrollbarWidth = (force?: boolean): number | undefined => {
   // safety check for SSR
   /* istanbul ignore next */
-  if (!document) {
+  if (typeof document === 'undefined') {
     return 0;
   }
 


### PR DESCRIPTION
# Description

In SSR context, if we check the existence of `document` variable like this, we get a ReferenceError, that will cause a build error in tools like Gatsby:

```
λ node -e "console.log(!!document)"
[eval]:1
console.log(!!document)
              ^

ReferenceError: document is not defined
    at [eval]:1:15
    at Script.runInThisContext (vm.js:122:20)
    at Object.runInThisContext (vm.js:329:38)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at evalScript (internal/bootstrap/node.js:590:27)
    at startup (internal/bootstrap/node.js:265:9)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
```

Instead, the correct way would be: 
```
λ node -e "console.log(typeof document === 'undefined')"
true
```


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
